### PR TITLE
Fix chip.py functions and tests.

### DIFF
--- a/dropbot/core.py
+++ b/dropbot/core.py
@@ -1,6 +1,8 @@
 # coding: utf-8
 import os
 import contextlib
+from collections import OrderedDict
+
 import pandas as pd
 
 from path_helpers import path

--- a/dropbot/tests/common.py
+++ b/dropbot/tests/common.py
@@ -1,0 +1,8 @@
+from path_helpers import path
+import os
+
+# Resolve data directory path (with support for frozen Python apps).
+DATA_DIR = path(os.environ.get('DROPBOT_DATA_DIR', path(__file__).parent.parent.joinpath('static'))).normpath()
+if not DATA_DIR.isdir():
+    # Add support for frozen apps, where data may be stored in a zip file.
+    DATA_DIR = os.path.join(*[d for d in DATA_DIR.splitall() if not d.endswith('.zip')])

--- a/dropbot/tests/test_actuation.py
+++ b/dropbot/tests/test_actuation.py
@@ -1,9 +1,8 @@
 from concurrent.futures import ThreadPoolExecutor
 import functools as ft
+import pytest
 
-from nose.tools import eq_, raises
 from dropbot.threshold import actuate_channels
-
 from test_threads import proxy_context
 
 
@@ -14,19 +13,17 @@ def test_actuate_channels_thread_safety():
     with proxy_context(ignore=True) as proxy:
         channels = range(10)
         with ThreadPoolExecutor(max_workers=len(channels)) as executor:
-            futures = [executor.submit(ft.partial(actuate_channels, proxy, [i],
-                                                  timeout=3))
-                       for i in channels]
+            futures = [executor.submit(ft.partial(actuate_channels, proxy, [i], timeout=3)) for i in channels]
 
             for channel, future in zip(channels, futures):
-                eq_(future.result(), [channel])
+                assert future.result() == [channel]
 
 
 def test_actuate_channels_count():
     'Verify number of actuated channels against requested channels.'
     with proxy_context(ignore=True) as proxy:
         channel_count = proxy.number_of_channels
-        eq_(channel_count, len(proxy.state_of_channels))
+        assert channel_count == len(proxy.state_of_channels)
         proxy.set_state_of_channels(channel_count * [0])
 
 
@@ -35,30 +32,26 @@ def test_actuate_channels_disabled_channels():
         with proxy.transaction_lock:
             original_mask = proxy.disabled_channels_mask
             new_mask = original_mask.copy()
-            channels = range(10)
+            channels = list(range(10))
 
             try:
                 new_mask[:] = 0
 
                 # Actuate without any channels disabled.
-                actuated = actuate_channels(proxy, channels,
-                                            allow_disabled=False)
-                eq_(actuated, channels)
+                actuated = actuate_channels(proxy, channels, allow_disabled=False)
+                assert actuated == channels
 
                 # Disable all even channels.
                 new_mask = original_mask.copy()
                 new_mask[::2] = 1
                 proxy.disabled_channels_mask = new_mask
 
-                # Verify exception is raised if disabled channels are not
-                # allowed.
-                raises(RuntimeError)(actuate_channels)(proxy, channels,
-                                                       allow_disabled=False)
+                # Test that an exception is raised if disabled channels are not allowed.
+                with pytest.raises(RuntimeError):
+                    actuate_channels(proxy, channels, allow_disabled=False)
 
-                # Verify exception is **not** raised if disabled channels
-                # **are** allowed.
-                actuated = actuate_channels(proxy, channels,
-                                            allow_disabled=True)
-                eq_(actuated, channels[1::2])
+                # Verify exception is not raised if disabled channels are allowed.
+                actuated = actuate_channels(proxy, channels, allow_disabled=True)
+                assert actuated == channels[1::2]
             finally:
                 proxy.disabled_channels_mask = original_mask

--- a/dropbot/tests/test_chip.py
+++ b/dropbot/tests/test_chip.py
@@ -1,46 +1,46 @@
-import nose.tools
-
 from dropbot.chip import get_all_intersections, draw, get_channel_neighbours
-from dropbot import DATA_DIR
 import svg_model
 
-
-SVG_PATH = DATA_DIR.joinpath('SCI-BOTS 90-pin array', 'device.svg')
+SVG_PATH = 'C:\\Users\\vr372\OneDrive - Yale University\Documents\py_projects\dropbot.py\dropbot\static\SCI-BOTS 90-pin array\device.svg'
 
 
 def test_intersections_from_svg():
     df_intersections = get_all_intersections(SVG_PATH)
 
-    # Test device has 92 electrodes (each electrode has a unique id). connected
-    # to 90 channels (two pairs of electrodes are each attached to a common
-    # electrode).
-    nose.tools.eq_(92, df_intersections.index.get_level_values('id')
-                   .drop_duplicates().shape[0])
+    # Test device has 92 electrodes (each electrode has a unique id)
+    # connected to 90 channels (two pairs of electrodes are each attached to a common electrode).
+    unique_ids = df_intersections.index.get_level_values('id').drop_duplicates()
+    assert unique_ids.shape[0] == 92
 
 
 def test_intersections_from_frame():
-    # Load data frame containing vertices from example SVG file.
+    # Load data frame containing vertices from example SVG fil
     df_shapes = svg_model.svg_shapes_to_df(SVG_PATH)
     df_intersections = get_all_intersections(df_shapes)
 
-    # Test device has 92 electrodes (each electrode has a unique id). connected
-    # to 90 channels (two pairs of electrodes are each attached to a common
-    # electrode).
-    nose.tools.eq_(92, df_intersections.index.get_level_values('id')
-                   .drop_duplicates().shape[0])
+    # Test device has 92 electrodes (each electrode has a unique id)
+    # connected to 90 channels (two pairs of electrodes are each attached to a common electrode).
+    unique_ids = df_intersections.index.get_level_values('id').drop_duplicates()
+    assert unique_ids.shape[0] == 92
 
 
 def test_draw_from_svg():
     # Draw detected neighbours.
-    ax, df_intersections = draw(SVG_PATH)
+    out_dict = draw(SVG_PATH)
+    assert list(out_dict.keys()) == ['axis', 'electrode_channels', 'df_shapes', 'channel_patches']
 
 
 def test_get_channel_neighbours():
     channel_neighbours = get_channel_neighbours(SVG_PATH)
 
     # Each channel should have 4 neighbours: `up`, `down`, `left`, and `right`.
-    # In the case where one of the neighbours does not exist, the corresponding
-    # entry is set `NaN` (which can be replaced using the `fillna` method).
+    # If one of the neighbours does not exist, the corresponding entry is set to `NaN`.
     counts = channel_neighbours.fillna(-1).groupby(level='channel').count()
-    nose.tools.eq_(4, counts.min())
-    nose.tools.eq_(4, counts.max())
+    assert counts.min().min() == 4  # Check minimum count across all channels
+    assert counts.max().max() == 4  # Check maximum count across all channels
+
+
+if __name__ == '__main__':
+    import pytest
+
+    pytest.main([__file__])

--- a/dropbot/tests/test_chip.py
+++ b/dropbot/tests/test_chip.py
@@ -1,7 +1,9 @@
 from dropbot.chip import get_all_intersections, draw, get_channel_neighbours
 import svg_model
+from common import DATA_DIR
+from os import sep
 
-SVG_PATH = 'C:\\Users\\vr372\OneDrive - Yale University\Documents\py_projects\dropbot.py\dropbot\static\SCI-BOTS 90-pin array\device.svg'
+SVG_PATH = f"{DATA_DIR}{sep}SCI-BOTS 90-pin array{sep}device.svg"
 
 
 def test_intersections_from_svg():

--- a/dropbot/tests/test_threads.py
+++ b/dropbot/tests/test_threads.py
@@ -3,7 +3,7 @@ import threading
 import time
 import dropbot as db
 import pandas as pd
-import pytest
+
 
 @contextmanager
 def proxy_context(*args, **kwargs):
@@ -24,6 +24,7 @@ def proxy_context(*args, **kwargs):
             proxy.terminate()
     else:
         raise IOError('Error connecting to DropBot.')
+
 
 def test_threadsafe():
     '''
@@ -72,4 +73,3 @@ def test_threadsafe():
     if exceptions:
         df_exceptions = pd.DataFrame(exceptions, columns=['thread_id', 'exception'])
         raise RuntimeError(f'The following exceptions occurred:\n{df_exceptions}')
-


### PR DESCRIPTION
## Changes:
- Implent pytests instead of nosetests. 
- Fix functions in chip.py
   - Add `df_shapes = df_shapes.loc[:, ~df_shapes.columns.duplicated()]` to get rid of duplicated 'id' column as a result of a bug in `svg_model.svg_shapes_to_df` function` everytime after it is called.
 
- Change the actuation test to use pytests. 
- Typo in chip.py fixed (extra character on top)
- `channel_neighbours = (df_neighbours['channel_neighbour'].loc[[i for c in range(120)` was not working as expected and looked way too confusing. Split this up into bits and now it appears to work.

## Note:
- The nosetests were converted to pytests for the test_watchdog and test_threading. Bu they do not work properly yet. 
- The channel neighbours creation may need further inspection. I think it is correct, but needs a proper valdiation.
