### PR TITLE
Fix tests: threading 

### DIFF
--- a/dropbot/tests/test_threads.py
+++ b/dropbot/tests/test_threads.py
@@ -34,6 +34,8 @@ def test_threadsafe_success():
     duration concurrently, for 10 seconds.  If an exception occurs in any
     thread, stop the test and raise a `RuntimeError` exception.
 
+    Threadlock used, so expect no errors.
+
     Raises
     ------
     RuntimeError
@@ -83,10 +85,7 @@ def test_threadsafe_fail():
     duration concurrently, for 10 seconds.  If an exception occurs in any
     thread, stop the test and raise a `RuntimeError` exception.
 
-    Raises
-    ------
-    RuntimeError
-        If an exception occurs in *any* thread.
+    No threadlock, so expects some errors to happen.
     '''
     exceptions = []
     exception_occurred = threading.Event()

--- a/dropbot/tests/test_threads.py
+++ b/dropbot/tests/test_threads.py
@@ -1,7 +1,7 @@
 from contextlib import contextmanager
 import threading
 import time
-import dropbot as db
+from dropbot.proxy import SerialProxy
 import pandas as pd
 
 
@@ -12,7 +12,7 @@ def proxy_context(*args, **kwargs):
     '''
     for i in range(2):
         try:
-            proxy = db.SerialProxy(*args, **kwargs)
+            proxy = SerialProxy(*args, **kwargs)
         except ValueError:
             time.sleep(0.5)
             print('Error connecting. Retrying...')
@@ -26,7 +26,7 @@ def proxy_context(*args, **kwargs):
         raise IOError('Error connecting to DropBot.')
 
 
-def test_threadsafe():
+def test_threadsafe_success():
     '''
     Repeatedly execute DropBot commands concurrently in multiple threads.
 
@@ -45,22 +45,22 @@ def test_threadsafe():
     with proxy_context(ignore=True) as proxy:
         stop_event = threading.Event()
 
-        def _test_thread(thread_id):
-            while not stop_event.wait(0.001):
-                try:
-                    if thread_id % 2 == 0:
-                        proxy.ram_free()
-                    else:
-                        proxy.detect_shorts(10)
-                except Exception as exception:
-                    exceptions.append((thread_id, exception))
-                    exception_occurred.set()
-                    break
+        def _test_thread_lock(thread_id):
+            with proxy.transaction_lock:
+                while not stop_event.wait(0.001):
+                    try:
+                        if thread_id % 2 == 0:
+                            proxy.ram_free()
+                        else:
+                            proxy.detect_shorts(10)
+                    except Exception as exception:
+                        exceptions.append((thread_id, exception))
+                        exception_occurred.set()
+                        break
 
-        threads = [threading.Thread(target=_test_thread, args=(i,)) for i in range(5)]
+        threads = [threading.Thread(target=_test_thread_lock, daemon=True, args=(i,)) for i in range(5)]
 
         for t in threads:
-            t.daemon = True
             t.start()
 
         for _ in range(10):
@@ -73,3 +73,51 @@ def test_threadsafe():
     if exceptions:
         df_exceptions = pd.DataFrame(exceptions, columns=['thread_id', 'exception'])
         raise RuntimeError(f'The following exceptions occurred:\n{df_exceptions}')
+
+
+def test_threadsafe_fail():
+    '''
+    Repeatedly execute DropBot commands concurrently in multiple threads.
+
+    Run multiple threads which repeatedly execute DropBot commands of varying
+    duration concurrently, for 10 seconds.  If an exception occurs in any
+    thread, stop the test and raise a `RuntimeError` exception.
+
+    Raises
+    ------
+    RuntimeError
+        If an exception occurs in *any* thread.
+    '''
+    exceptions = []
+    exception_occurred = threading.Event()
+
+    with proxy_context(ignore=True) as proxy:
+        stop_event = threading.Event()
+
+        def _test_thread_not_locked(thread_id):
+            while not stop_event.wait(0.001):
+                try:
+                    if thread_id % 2 == 0:
+                        proxy.ram_free()
+                    else:
+                        proxy.detect_shorts(10)
+                except Exception as exception:
+                    exceptions.append((thread_id, exception))
+                    exception_occurred.set()
+                    break
+
+        threads = []
+        for i in range(5):
+            threads.append(threading.Thread(target=_test_thread_not_locked, daemon=True, args=(i,)))
+
+        for t in threads:
+            t.start()
+
+        for _ in range(10):
+            if exception_occurred.wait(1.0):
+                break
+        else:
+            return
+        stop_event.set()
+
+    assert len(exceptions) > 0


### PR DESCRIPTION
## Changes:
- New split tests for test_threading.py:
   - Test with `proxy.threadlock` used and not used
   - The case with the lock should work well and all operations requested done.
   - The case without it should raise exceptions which the tests checks for that it is produced. 

## How to test:
- Run `pytest test_threads.py` (this file: [test_threads.py](https://github.com/Vigne-hub/dropbot.py/tree/fix_tests/dropbot/tests/test_threads.py))
- Have a dropbot connection