### PR TITLE
conda-build + reboot gone.

### DIFF
--- a/.conda-recipe/conda_build_config.yaml
+++ b/.conda-recipe/conda_build_config.yaml
@@ -1,0 +1,5 @@
+python:
+  - 3.9  # Specify the Python version to use for the build
+
+numpy:
+  - 1.25  # Pin numpy version for compatibility, if necessary

--- a/.conda-recipe/meta.yaml
+++ b/.conda-recipe/meta.yaml
@@ -27,14 +27,14 @@ build:
 
 requirements:
   build:
-        - python {{ python }}
+        - python
         - pint
         - numpy
         - pandas
         - pandoc
         - jinja2
         - pytables
-        - protobuf
+        - protobuf 3.20.*
         - tabulate
         - aiosignal
         - matplotlib
@@ -62,7 +62,6 @@ requirements:
 #     package.
 outputs:
   - name: {{ PKG_NAME }}-dev
-    noarch: generic
     files:
       - share
     requirements:
@@ -73,12 +72,11 @@ outputs:
         - base-node-rpc-dev
         - teensy-minimal-rpc-dev
   - name: {{ PKG_NAME }}
-    noarch: python
     files:
       - {{ SP_DIR }}/{{ MODULE_NAME }}
     requirements:
       run:
-        - python >=3.6
+        - python
         - {{ pin_subpackage(PKG_NAME + '-dev', max_pin='x') }}
         - pint
         - numpy
@@ -86,7 +84,7 @@ outputs:
         - pandoc
         - jinja2
         - pytables
-        - protobuf
+        - protobuf 3.20.* 
         - tabulate
         - aiosignal
         - matplotlib

--- a/.conda-recipe/meta.yaml
+++ b/.conda-recipe/meta.yaml
@@ -79,7 +79,7 @@ outputs:
     requirements:
       run:
         - python >=3.6
-        - {{ pin_subpackage(PKG_NAME + '-dev', max_pin='x.x') }}
+        - {{ pin_subpackage(PKG_NAME + '-dev', max_pin='x') }}
         - pint
         - numpy
         - pandas
@@ -129,5 +129,4 @@ about:
 # source will be downloaded prior to filling in jinja templates
 # Example assumes that this folder has setup.py in it
 source:
-  git_url: ../
-#  path: ..
+  git_url: https://github.com/Vigne-hub/dropbot.py.git

--- a/dropbot/tests/test_watchdog.py
+++ b/dropbot/tests/test_watchdog.py
@@ -4,6 +4,7 @@ import time
 import pytest
 import serial
 from six.moves import range
+from dropbot.proxy import SerialProxy, NoPower, I2cAddressNotSet
 
 # Watchdog enable bit mask
 WDOG_STCTRLH_WDOGEN = 0x01
@@ -35,12 +36,11 @@ def proxy():
         run on standalone control board hardware (i.e., not connected to power
         or I2C bus).
     '''
-    import dropbot as db
-    import dropbot.proxy
+
 
     # XXX Ignore non-critical exceptions during initialization.
-    proxy_ = db.SerialProxy(ignore=[db.proxy.NoPower,
-                                    db.proxy.I2cAddressNotSet])
+    proxy_ = SerialProxy(ignore=[NoPower,
+                                    I2cAddressNotSet])
     yield proxy_
     proxy_.terminate()
 


### PR DESCRIPTION
##Changes:
- Able to compile with linux (wsl on windows). Using `conda build RECIPE_DIRECTORY -c conda-forge -c alexsk` but with some errors (see [comment](https://github.com/AlexSklav/dropbot.py/pull/3#issuecomment-2378535658))
- No more reboot function -- commented out since it appears to have not been ported from python 2 to give the same behaviour as before.
